### PR TITLE
Fix for freetype on with cpp-11

### DIFF
--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -58,7 +58,7 @@ function build() {
 
 		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
 
-		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
+		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no  --without-harfbuzz \
 			CFLAGS="$FAT_CFLAGS -pipe -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean 
 		make


### PR DESCRIPTION
This fixes issues loading fonts with missing symbols for freetype like this:-

Undefined symbols for architecture x86_64:
"_hb_ft_font_create", referenced from:
_af_face_globals_new in freetype.a(autofit.o)

I found the solution in the universal option for the homebrew recipe formula for freetype (brew edit freetype).
